### PR TITLE
fix(melos): ignore 'unused' errors when cleaning coverage

### DIFF
--- a/ubuntu_flutter_template/__brick__/melos.yaml
+++ b/ubuntu_flutter_template/__brick__/melos.yaml
@@ -35,6 +35,7 @@ scripts:
         '**/*.mocks.dart' \
         '**/l10n/*.dart' \
         '**/*.pb*.dart' \
+        --ignore-errors unused,unused \
         -o coverage/lcov.info
 
   # format all packages


### PR DESCRIPTION
This suppresses errors from `lcov` when stripping the coverage files, in cases where a provided exclusion pattern isn't present in the coverage file, e.g.:

```
lcov: ERROR: (unused) 'exclude' pattern '**/*.freezed.dart' is unused.
    (use "lcov --ignore-errors unused ..." to bypass this error)
```

`unused` is provided twice in the argument to completely suppress the error, see `man lcov`:

```
Note that the tool will generate a warning (rather than a fatal error) unless you ignore the error  two  (or  more)
              times:
                     lcov ... --ignore-errors source,source ...
```